### PR TITLE
:seedling: Remove pointer from device.Reconcile result

### DIFF
--- a/controllers/hivelocitymachine_controller.go
+++ b/controllers/hivelocitymachine_controller.go
@@ -193,13 +193,10 @@ func (r *HivelocityMachineReconciler) reconcileNormal(ctx context.Context, machi
 
 	// reconcile device
 	result, err := device.NewService(machineScope).Reconcile(ctx)
-	if result == nil {
-		result = &reconcile.Result{}
-	}
 	if err != nil {
-		return *result, fmt.Errorf("failed to reconcile device for HivelocityMachine %s/%s: %w", hivelocityMachine.Namespace, hivelocityMachine.Name, err)
+		return result, fmt.Errorf("failed to reconcile device for HivelocityMachine %s/%s: %w", hivelocityMachine.Namespace, hivelocityMachine.Name, err)
 	}
-	return *result, nil
+	return result, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
**What type of PR is this?**
/kind other

**What this PR does / why we need it**:
The pointer adds additional complexity that is making the code harder to read. Removing it means that we cannot just return a nil value in device.Reconcile though, which is a small inconvenience.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
