### PR TITLE
:seedling: Remove APIReader from  scope

### DIFF
--- a/controllers/hivelocitymachine_controller.go
+++ b/controllers/hivelocitymachine_controller.go
@@ -130,7 +130,6 @@ func (r *HivelocityMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			Cluster:           cluster,
 			HivelocityCluster: hvCluster,
 			HVClient:          hvClient,
-			APIReader:         r.APIReader,
 		},
 		Machine:           machine,
 		HivelocityMachine: hivelocityMachine,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removing the APIReader from  scope, as it is not used in many places. The occurences where it is used, we can replace it. Instead of using the elaborate AcquireSecret function, we can just use the normal client.Get method. We don't need to put finalizers or anything on these secrets that we handle there, as they are managed by ClusterAPI anyway. Only the HivelocitySecret has to be managed by us.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
