### PR TITLE
:seedling: Update naming of device vs machine

### DIFF
--- a/api/v1alpha1/conditions_const.go
+++ b/api/v1alpha1/conditions_const.go
@@ -34,10 +34,10 @@ const (
 )
 
 const (
-	// DeviceBootstrapReadyCondition reports on current status of the device. BootstrapReady indicates the bootstrap is ready.
-	DeviceBootstrapReadyCondition clusterv1.ConditionType = "DeviceBootstrapReady"
-	// DeviceBootstrapNotReadyReason bootstrap not ready yet.
-	DeviceBootstrapNotReadyReason = "DeviceBootstrapNotReady"
+	// MachineBootstrapReadyCondition reports on current status of the machine. BootstrapReady indicates the bootstrap is ready.
+	MachineBootstrapReadyCondition clusterv1.ConditionType = "MachineBootstrapReady"
+	// MachineBootstrapNotReadyReason bootstrap not ready yet.
+	MachineBootstrapNotReadyReason = "MachineBootstrapNotReady"
 )
 
 const (

--- a/api/v1alpha1/hivelocitymachine_types.go
+++ b/api/v1alpha1/hivelocitymachine_types.go
@@ -113,7 +113,7 @@ type HivelocityMachineStatus struct {
 	// +optional
 	Ready bool `json:"ready"`
 
-	// Addresses contains the devices's associated addresses.
+	// Addresses contains the machine's associated addresses.
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// Region contains the name of the Hivelocity location the device is running.
@@ -148,7 +148,7 @@ type HivelocityMachineStatus struct {
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="Device type"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.deviceState",description="Hivelocity device state"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
-// +kubebuilder:printcolumn:name="DeviceID",type="string",JSONPath=".spec.providerID",description="Hivelocity device ID"
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="ProviderID of machine object"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this HivelocityMachine"
 // +k8s:defaulter-gen=true
 

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -26,8 +26,8 @@ type SSHKey struct {
 	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
-// HivelocityDeviceType defines the Hivelocity Machine type.
-type HivelocityDeviceType string // question: rename to HivelocityDeviceType ?
+// HivelocityDeviceType defines the Hivelocity device type.
+type HivelocityDeviceType string
 
 // ResourceLifecycle configures the lifecycle of a resource.
 type ResourceLifecycle string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hivelocitymachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hivelocitymachines.yaml
@@ -40,9 +40,9 @@ spec:
       jsonPath: .status.ready
       name: Ready
       type: string
-    - description: Hivelocity device ID
+    - description: ProviderID of machine object
       jsonPath: .spec.providerID
-      name: DeviceID
+      name: ProviderID
       type: string
     - description: Machine object which owns with this HivelocityMachine
       jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
@@ -107,7 +107,7 @@ spec:
             description: HivelocityMachineStatus defines the observed state of HivelocityMachine.
             properties:
               addresses:
-                description: Addresses contains the devices's associated addresses.
+                description: Addresses contains the machine's associated addresses.
                 items:
                   description: MachineAddress contains information for the node's
                     address.

--- a/controllers/hivelocitymachine_controller.go
+++ b/controllers/hivelocitymachine_controller.go
@@ -62,7 +62,7 @@ type HivelocityMachineReconciler struct {
 func (r *HivelocityMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	// Fetch the HivelocityMachine device.
+	// Fetch the HivelocityMachine.
 	hivelocityMachine := &infrav1.HivelocityMachine{}
 	err := r.Get(ctx, req.NamespacedName, hivelocityMachine)
 	if err != nil {
@@ -161,10 +161,10 @@ func (r *HivelocityMachineReconciler) reconcileDelete(ctx context.Context, machi
 	machineScope.Info("Reconciling HivelocityMachine delete")
 	hivelocityMachine := machineScope.HivelocityMachine
 
-	// delete devices
+	// delete device
 	result, err := device.NewService(machineScope).Delete(ctx)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to delete devices for HivelocityMachine %s/%s: %w", hivelocityMachine.Namespace, hivelocityMachine.Name, err)
+		return reconcile.Result{}, fmt.Errorf("failed to delete device for HivelocityMachine %s/%s: %w", hivelocityMachine.Namespace, hivelocityMachine.Name, err)
 	}
 
 	if result != nil {

--- a/controllers/hivelocitymachine_controller_test.go
+++ b/controllers/hivelocitymachine_controller_test.go
@@ -173,7 +173,7 @@ var _ = Describe("HivelocityMachineReconciler", func() {
 				if err := testEnv.Get(ctx, machineKey, hvMachine); err != nil {
 					return false
 				}
-				return isPresentAndFalseWithReason(machineKey, hvMachine, infrav1.DeviceBootstrapReadyCondition, infrav1.DeviceBootstrapNotReadyReason)
+				return isPresentAndFalseWithReason(machineKey, hvMachine, infrav1.MachineBootstrapReadyCondition, infrav1.MachineBootstrapNotReadyReason)
 			}, timeout, time.Second).Should(BeTrue())
 
 			By("setting the bootstrap data")
@@ -195,9 +195,9 @@ var _ = Describe("HivelocityMachineReconciler", func() {
 				if err := testEnv.Get(ctx, machineKey, hvMachine); err != nil {
 					return false
 				}
-				objectCondition := conditions.Get(hvMachine, infrav1.DeviceBootstrapReadyCondition)
+				objectCondition := conditions.Get(hvMachine, infrav1.MachineBootstrapReadyCondition)
 				fmt.Println(objectCondition)
-				return isPresentAndTrue(machineKey, hvMachine, infrav1.DeviceBootstrapReadyCondition)
+				return isPresentAndTrue(machineKey, hvMachine, infrav1.MachineBootstrapReadyCondition)
 			}, timeout, time.Second).Should(BeTrue())
 
 			testEnv.GetLogger().Info("############################################################################")

--- a/pkg/services/hivelocity/device/device.go
+++ b/pkg/services/hivelocity/device/device.go
@@ -82,8 +82,8 @@ func (s *Service) Reconcile(ctx context.Context) (_ ctrl.Result, err error) {
 		log.Info("Bootstrap not ready - requeuing")
 		conditions.MarkFalse(
 			s.scope.HivelocityMachine,
-			infrav1.DeviceBootstrapReadyCondition,
-			infrav1.DeviceBootstrapNotReadyReason,
+			infrav1.MachineBootstrapReadyCondition,
+			infrav1.MachineBootstrapNotReadyReason,
 			clusterv1.ConditionSeverityInfo,
 			"bootstrap not ready yet",
 		)
@@ -92,7 +92,7 @@ func (s *Service) Reconcile(ctx context.Context) (_ ctrl.Result, err error) {
 
 	conditions.MarkTrue(
 		s.scope.HivelocityMachine,
-		infrav1.DeviceBootstrapReadyCondition,
+		infrav1.MachineBootstrapReadyCondition,
 	)
 
 	initialState := s.scope.HivelocityMachine.Spec.Status.ProvisioningState
@@ -129,9 +129,9 @@ func (s *Service) getSSHKeyIDFromSSHKeyName(ctx context.Context, sshKey *infrav1
 		sshKey.Name)
 }
 
-// Delete implements delete method of the HV device.
+// Delete implements delete method of the HivelocityMachine.
 func (s *Service) Delete(ctx context.Context) (_ *ctrl.Result, err error) {
-	// find current device
+	// find associated device
 	device, err := s.getAssociatedDevice(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find device: %w", err)
@@ -237,7 +237,7 @@ func createTags(clusterName, machineName string, isControlPlane bool) []string {
 	}
 }
 
-// setMachineAddress gets the address from the device and sets it on the Machine object.
+// setMachineAddress gets the address from the device and sets it on the HivelocityMachine object.
 func setMachineAddress(hvMachine *infrav1.HivelocityMachine, hvDevice *hv.BareMetalDevice) {
 	hvMachine.Status.Addresses = []clusterv1.MachineAddress{
 		{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Hivelocity has devices, which we want to provision with the HivelocityMachine objects. So everything that has "machine" in its name should refer to the Kubernetes object, whereas everything related to "device" has to be connected to the actual Hivelocity devices we target with the Hivelocity API.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
