### PR TITLE
:sparkles: Add DeviceTag object

### DIFF
--- a/api/v1alpha1/conditions_const.go
+++ b/api/v1alpha1/conditions_const.go
@@ -28,9 +28,9 @@ const (
 	// DeviceOffReason device is off.
 	DeviceOffReason = "DeviceOff"
 
-	// DeviceDeletedReason (Severity=Error) documents a HivelocityMachine controller detecting
+	// DeviceNotFoundReason (Severity=Error) documents a HivelocityMachine controller detecting
 	// the underlying device has been deleted unexpectedly.
-	DeviceDeletedReason = "DeviceDeleted"
+	DeviceNotFoundReason = "DeviceNotFound"
 )
 
 const (

--- a/api/v1alpha1/hivelocitycluster_types.go
+++ b/api/v1alpha1/hivelocitycluster_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/hvtag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -83,6 +84,14 @@ func (r *HivelocityCluster) GetConditions() clusterv1.Conditions {
 // SetConditions sets the underlying service state of the HivelocityCluster to the predescribed clusterv1.Conditions.
 func (r *HivelocityCluster) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
+}
+
+// DeviceTag returns a DeviceTag object for the cluster tag.
+func (r *HivelocityCluster) DeviceTag() hvtag.DeviceTag {
+	return hvtag.DeviceTag{
+		Key:   hvtag.DeviceTagKeyCluster,
+		Value: r.Name,
+	}
 }
 
 func init() {

--- a/api/v1alpha1/hivelocitycluster_types_test.go
+++ b/api/v1alpha1/hivelocitycluster_types_test.go
@@ -14,22 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package device implements functions to manage the lifecycle of Hivelocity devices.
-package device
+package v1alpha1
 
 import (
 	"testing"
 
-	mockclient "github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/client/mock"
-	hv "github.com/hivelocity/hivelocity-client-go/client"
-	"github.com/stretchr/testify/require"
+	"github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/hvtag"
 )
 
-func Test_chooseAvailableFromList(t *testing.T) {
-	devices := []*hv.BareMetalDevice{
-		&mockclient.NoTagsDevice,
-		&mockclient.FreeDevice,
+func TestClusterDeviceTag(t *testing.T) {
+	hvCluster := HivelocityCluster{}
+	hvCluster.Name = "hvclustername"
+	deviceTag := hvCluster.DeviceTag()
+	expectDeviceTag := hvtag.DeviceTag{Key: hvtag.DeviceTagKeyCluster, Value: "hvclustername"}
+	if deviceTag != expectDeviceTag {
+		t.Fatalf("wrong device tag. Expect %+v, got %+v", expectDeviceTag, deviceTag)
 	}
-	_, err := chooseAvailableFromList(devices, "fooDeviceType", "my-cluster", "my-machine")
-	require.ErrorIs(t, err, errNoDeviceAvailable)
 }

--- a/api/v1alpha1/hivelocitymachine_types.go
+++ b/api/v1alpha1/hivelocitymachine_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	hvclient "github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/client"
+	"github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/hvtag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
@@ -174,6 +175,14 @@ func (r *HivelocityMachine) GetConditions() clusterv1.Conditions {
 // SetConditions sets the underlying service state of the HivelocityMachine to the predescribed clusterv1.Conditions.
 func (r *HivelocityMachine) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
+}
+
+// DeviceTag returns a DeviceTag object for the machine tag.
+func (r *HivelocityMachine) DeviceTag() hvtag.DeviceTag {
+	return hvtag.DeviceTag{
+		Key:   hvtag.DeviceTagKeyMachine,
+		Value: r.Name,
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/hivelocitymachine_types_test.go
+++ b/api/v1alpha1/hivelocitymachine_types_test.go
@@ -14,22 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package device implements functions to manage the lifecycle of Hivelocity devices.
-package device
+package v1alpha1
 
 import (
 	"testing"
 
-	mockclient "github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/client/mock"
-	hv "github.com/hivelocity/hivelocity-client-go/client"
-	"github.com/stretchr/testify/require"
+	"github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/hvtag"
 )
 
-func Test_chooseAvailableFromList(t *testing.T) {
-	devices := []*hv.BareMetalDevice{
-		&mockclient.NoTagsDevice,
-		&mockclient.FreeDevice,
+func TestMachineDeviceTag(t *testing.T) {
+	hvMachine := HivelocityMachine{}
+	hvMachine.Name = "hvmachinename"
+	deviceTag := hvMachine.DeviceTag()
+	expectDeviceTag := hvtag.DeviceTag{Key: hvtag.DeviceTagKeyMachine, Value: "hvmachinename"}
+	if deviceTag != expectDeviceTag {
+		t.Fatalf("wrong device tag. Expect %+v, got %+v", expectDeviceTag, deviceTag)
 	}
-	_, err := chooseAvailableFromList(devices, "fooDeviceType", "my-cluster", "my-machine")
-	require.ErrorIs(t, err, errNoDeviceAvailable)
 }

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -276,7 +276,7 @@ def ensure_boilerplate_file(file_name, refs, regexs, not_generated_files_to_skip
         new_content += year_replacer.sub(current_year, licence_header, 1)
 
         # actual content
-        new_content += os.linesep + content_without_specials
+        new_content += os.linesep + os.linesep + content_without_specials
 
         f.seek(0)
         f.write(new_content)

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 
 	infrav1 "github.com/hivelocity/cluster-api-provider-hivelocity/api/v1alpha1"
+	"github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/hvtag"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -102,6 +103,20 @@ func (m *MachineScope) Namespace() string {
 // PatchObject persists the machine spec and status.
 func (m *MachineScope) PatchObject(ctx context.Context) error {
 	return m.patchHelper.Patch(ctx, m.HivelocityMachine)
+}
+
+// DeviceTagMachineType returns a DeviceTag object for the cluster tag.
+func (m *MachineScope) DeviceTagMachineType() hvtag.DeviceTag {
+	var value string
+	if m.IsControlPlane() {
+		value = "control_plane"
+	} else {
+		value = "worker"
+	}
+	return hvtag.DeviceTag{
+		Key:   hvtag.DeviceTagKeyCluster,
+		Value: value,
+	}
 }
 
 // SetError sets the ErrorMessage and ErrorReason fields on the machine and logs

--- a/pkg/services/hivelocity/hvtag/hvtag.go
+++ b/pkg/services/hivelocity/hvtag/hvtag.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hvtag contains objects and utility functions to handle tags of Hivelocity devices.
+package hvtag
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+// DeviceTagKey defines the key of the key-value pair that is stored as tag of Hivelocity devices.
+type DeviceTagKey string
+
+const (
+	// DeviceTagKeyMachine is the key for the name of the associated HivelocityMachine object.
+	DeviceTagKeyMachine DeviceTagKey = "caphv-machine-name"
+
+	// DeviceTagKeyCluster is the key for the name of the associated HivelocityCluster object.
+	DeviceTagKeyCluster DeviceTagKey = "caphv-cluster-name"
+
+	// DeviceTagKeyDeviceType is the key for the device type that users can reference in HivelocityMachine.Spec.
+	DeviceTagKeyDeviceType DeviceTagKey = "caphv-device-type"
+
+	// DeviceTagKeyMachineType is the key for the machine type, i.e. worker, control_plane.
+	DeviceTagKeyMachineType DeviceTagKey = "caphv-machine-type"
+)
+
+// Prefix returns the prefix based on this DeviceTagKey used in Hivelocity tag strings.
+func (key DeviceTagKey) Prefix() string {
+	return fmt.Sprintf("%s=", key)
+}
+
+var (
+	// ErrDeviceTagKeyInvalid indicates that the device tag key is invalid.
+	ErrDeviceTagKeyInvalid = fmt.Errorf("invalid device tag key")
+	// ErrDeviceTagInvalidFormat indicates that the device tag has an invalid format.
+	ErrDeviceTagInvalidFormat = fmt.Errorf("invalid format of device tag")
+	// ErrDeviceTagEmptyKey indicates that the device tag has an empty key.
+	ErrDeviceTagEmptyKey = fmt.Errorf("device tag has empty key")
+	// ErrDeviceTagEmptyValue indicates that the device tag has an empty value.
+	ErrDeviceTagEmptyValue = fmt.Errorf("device tag has empty value")
+	// ErrMultipleDeviceTagsFound indicates that multiple device tags have been found in a list.
+	ErrMultipleDeviceTagsFound = fmt.Errorf("found multiple device tags")
+	// ErrDeviceTagNotFound indicates that no device tag has been found.
+	ErrDeviceTagNotFound = fmt.Errorf("no device tag found")
+)
+
+// IsValid checks whether a DeviceTagKey is valid.
+func (key DeviceTagKey) IsValid() bool {
+	return key == DeviceTagKeyMachine ||
+		key == DeviceTagKeyCluster ||
+		key == DeviceTagKeyDeviceType ||
+		key == DeviceTagKeyMachineType
+}
+
+// DeviceTag defines the object that represents a key-value pair that is stored as tag of Hivelocity devices.
+type DeviceTag struct {
+	Key   DeviceTagKey
+	Value string
+}
+
+// DeviceTagFromList takes the tag of a HV device and returns a DeviceTag or an error if it is invalid.
+func DeviceTagFromList(key DeviceTagKey, tagList []string) (DeviceTag, error) {
+	var found bool
+	var deviceTag DeviceTag
+	var err error
+
+	for _, tagString := range tagList {
+		// filter out irrelevant tagStrings quickly
+		if !strings.HasPrefix(tagString, key.Prefix()) {
+			continue
+		}
+
+		// get DeviceTag from tagString
+		deviceTag, err = deviceTagFromString(tagString)
+		if err != nil {
+			continue
+		}
+
+		// additional check if key is correct - probably not necessary due to HasPrefix check
+		if deviceTag.Key != key {
+			continue
+		}
+
+		// Check whether a correct DeviceTag has been found already. If so, return with error.
+		if found {
+			return DeviceTag{}, ErrMultipleDeviceTagsFound
+		}
+		found = true
+	}
+
+	if !found {
+		return DeviceTag{}, ErrDeviceTagNotFound
+	}
+
+	return deviceTag, nil
+}
+
+// MachineTagFromList returns the machine tag from a list of tag strings.
+func MachineTagFromList(tagList []string) (DeviceTag, error) {
+	return DeviceTagFromList(DeviceTagKeyMachine, tagList)
+}
+
+// ClusterTagFromList returns the machine tag from a list of tag strings.
+func ClusterTagFromList(tagList []string) (DeviceTag, error) {
+	return DeviceTagFromList(DeviceTagKeyCluster, tagList)
+}
+
+// DeviceTypeTagFromList returns the machine tag from a list of tag strings.
+func DeviceTypeTagFromList(tagList []string) (DeviceTag, error) {
+	return DeviceTagFromList(DeviceTagKeyDeviceType, tagList)
+}
+
+// deviceTagFromString takes the tag of a HV device and returns a DeviceTag or an error if it is invalid.
+func deviceTagFromString(tagString string) (DeviceTag, error) {
+	tagElements := strings.Split(tagString, "=")
+	if len(tagElements) != 2 {
+		return DeviceTag{}, ErrDeviceTagInvalidFormat
+	}
+
+	key := DeviceTagKey(tagElements[0])
+	value := tagElements[1]
+
+	if key == "" {
+		return DeviceTag{}, ErrDeviceTagEmptyKey
+	}
+	if value == "" {
+		return DeviceTag{}, ErrDeviceTagEmptyValue
+	}
+
+	if !key.IsValid() {
+		return DeviceTag{}, ErrDeviceTagKeyInvalid
+	}
+
+	return DeviceTag{key, value}, nil
+}
+
+// ToString returns the string representation of a DeviceTag object.
+func (deviceTag DeviceTag) ToString() string {
+	return string(deviceTag.Key) + "=" + deviceTag.Value
+}
+
+// IsInStringList checks whether a DeviceTag object can be found in a list of tag strings.
+func (deviceTag DeviceTag) IsInStringList(tagList []string) bool {
+	return slices.Contains(tagList, deviceTag.ToString())
+}
+
+// RemoveFromList removes all tag strings from a list that equal the string representation of DeviceTag.
+func (deviceTag DeviceTag) RemoveFromList(tagList []string) (newTagList []string, updated bool) {
+	newTagList = make([]string, 0, len(tagList))
+	for _, tagString := range tagList {
+		// append all tag strings to newTagList which do not equal this device tag
+		if tagString == deviceTag.ToString() {
+			updated = true
+		} else {
+			newTagList = append(newTagList, tagString)
+		}
+	}
+	return newTagList, updated
+}

--- a/pkg/services/hivelocity/hvtag/hvtag_test.go
+++ b/pkg/services/hivelocity/hvtag/hvtag_test.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hvtag
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHVTag(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HVTag Suite")
+}
+
+var _ = Describe("Test DeviceTagKey.Prefix", func() {
+	type testCaseDeviceTagKeyPrefix struct {
+		key          DeviceTagKey
+		expectPrefix string
+	}
+
+	DescribeTable("Test DeviceTagKey.Prefix",
+		func(tc testCaseDeviceTagKeyPrefix) {
+			Expect(tc.key.Prefix()).Should(Equal(tc.expectPrefix))
+		},
+		Entry("cluster key", testCaseDeviceTagKeyPrefix{
+			key:          DeviceTagKeyCluster,
+			expectPrefix: "caphv-cluster-name=",
+		}),
+		Entry("machine key", testCaseDeviceTagKeyPrefix{
+			key:          DeviceTagKeyMachine,
+			expectPrefix: "caphv-machine-name=",
+		}),
+	)
+})
+
+var _ = Describe("Test DeviceTagKey.IsValid", func() {
+	type testCaseDeviceTagKeyIsValid struct {
+		key           DeviceTagKey
+		expectIsValid bool
+	}
+
+	DescribeTable("Test DeviceTagKey.IsValid",
+		func(tc testCaseDeviceTagKeyIsValid) {
+			Expect(tc.key.IsValid()).Should(Equal(tc.expectIsValid))
+		},
+		Entry("cluster key", testCaseDeviceTagKeyIsValid{
+			key:           DeviceTagKeyCluster,
+			expectIsValid: true,
+		}),
+		Entry("machine key", testCaseDeviceTagKeyIsValid{
+			key:           DeviceTagKeyMachine,
+			expectIsValid: true,
+		}),
+		Entry("device type key", testCaseDeviceTagKeyIsValid{
+			key:           DeviceTagKeyDeviceType,
+			expectIsValid: true,
+		}),
+		Entry("machine type key", testCaseDeviceTagKeyIsValid{
+			key:           DeviceTagKeyMachineType,
+			expectIsValid: true,
+		}),
+		Entry("other key", testCaseDeviceTagKeyIsValid{
+			key:           "caph-other",
+			expectIsValid: false,
+		}),
+	)
+})
+
+var _ = Describe("TestDeviceTagFromList", func() {
+	type testCaseDeviceTagFromList struct {
+		key             DeviceTagKey
+		tagList         []string
+		expectDeviceTag DeviceTag
+		expectError     error
+	}
+
+	DescribeTable("TestDeviceTagFromList",
+		func(tc testCaseDeviceTagFromList) {
+			deviceTag, err := DeviceTagFromList(tc.key, tc.tagList)
+			if tc.expectError != nil {
+				Expect(err).ToNot(BeNil())
+				Expect(err).Should(Equal(tc.expectError))
+			}
+			Expect(deviceTag).Should(Equal(tc.expectDeviceTag))
+		},
+		Entry("valid and unique device tag - only one tag in list", testCaseDeviceTagFromList{
+			key:             DeviceTagKeyCluster,
+			tagList:         []string{DeviceTagKeyCluster.Prefix() + "value"},
+			expectDeviceTag: DeviceTag{DeviceTagKeyCluster, "value"},
+			expectError:     nil,
+		}),
+		Entry("valid and unique device tag - multiple tags in list", testCaseDeviceTagFromList{
+			key:             DeviceTagKeyCluster,
+			tagList:         []string{DeviceTagKeyCluster.Prefix() + "value", DeviceTagKeyMachine.Prefix() + "othervalue", "othertag"},
+			expectDeviceTag: DeviceTag{DeviceTagKeyCluster, "value"},
+			expectError:     nil,
+		}),
+		Entry("valid but not unique device tag", testCaseDeviceTagFromList{
+			key:             DeviceTagKeyCluster,
+			tagList:         []string{DeviceTagKeyCluster.Prefix() + "value", DeviceTagKeyCluster.Prefix() + "othervalue"},
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrMultipleDeviceTagsFound,
+		}),
+		Entry("valid device tag existing twice", testCaseDeviceTagFromList{
+			key:             DeviceTagKeyCluster,
+			tagList:         []string{DeviceTagKeyCluster.Prefix() + "value", DeviceTagKeyCluster.Prefix() + "value"},
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrMultipleDeviceTagsFound,
+		}),
+		Entry("valid but not unique device tag - key exists twice", testCaseDeviceTagFromList{
+			key:             DeviceTagKeyCluster,
+			tagList:         []string{DeviceTagKeyCluster.Prefix() + "value", string(DeviceTagKeyCluster) + "value"},
+			expectDeviceTag: DeviceTag{DeviceTagKeyCluster, "value"},
+			expectError:     nil,
+		}),
+		Entry("device tag does not exist", testCaseDeviceTagFromList{
+			key:             DeviceTagKeyCluster,
+			tagList:         []string{DeviceTagKeyMachine.Prefix() + "value", string(DeviceTagKeyCluster) + "value"},
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrDeviceTagNotFound,
+		}),
+		Entry("device tag has empty value", testCaseDeviceTagFromList{
+			key:             DeviceTagKeyCluster,
+			tagList:         []string{DeviceTagKeyCluster.Prefix(), DeviceTagKeyMachine.Prefix() + "othervalue"},
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrDeviceTagNotFound,
+		}),
+	)
+})
+
+var _ = Describe("TestMachineTagFromList", func() {
+	It("returns a DeviceTag with DeviceTagKeyMachine", func() {
+		deviceTag, err := MachineTagFromList([]string{DeviceTagKeyMachine.Prefix() + "value", string(DeviceTagKeyCluster) + "value"})
+		Expect(err).To(BeNil())
+		Expect(deviceTag).To(Equal(DeviceTag{Key: DeviceTagKeyMachine, Value: "value"}))
+	})
+})
+
+var _ = Describe("TestClusterTagFromList", func() {
+	It("returns a DeviceTag with DeviceTagKeyCluster", func() {
+		deviceTag, err := ClusterTagFromList([]string{DeviceTagKeyCluster.Prefix() + "value", string(DeviceTagKeyCluster) + "value"})
+		Expect(err).To(BeNil())
+		Expect(deviceTag).To(Equal(DeviceTag{Key: DeviceTagKeyCluster, Value: "value"}))
+	})
+})
+
+var _ = Describe("TestDeviceTypeTagFromList", func() {
+	It("returns a DeviceTag with DeviceTagKeyDeviceType", func() {
+		deviceTag, err := DeviceTypeTagFromList([]string{DeviceTagKeyDeviceType.Prefix() + "value", string(DeviceTagKeyDeviceType) + "value"})
+		Expect(err).To(BeNil())
+		Expect(deviceTag).To(Equal(DeviceTag{Key: DeviceTagKeyDeviceType, Value: "value"}))
+	})
+})
+
+var _ = Describe("deviceTagFromString", func() {
+	type testCaseDeviceTagFromString struct {
+		tagString       string
+		expectDeviceTag DeviceTag
+		expectError     error
+	}
+
+	DescribeTable("deviceTagFromString",
+		func(tc testCaseDeviceTagFromString) {
+			deviceTag, err := deviceTagFromString(tc.tagString)
+			if tc.expectError != nil {
+				Expect(err).ToNot(BeNil())
+				Expect(err).Should(Equal(tc.expectError))
+			}
+			Expect(deviceTag).Should(Equal(tc.expectDeviceTag))
+		},
+		Entry("valid device tag - cluster", testCaseDeviceTagFromString{
+			tagString:       "caphv-cluster-name=mycluster",
+			expectDeviceTag: DeviceTag{DeviceTagKeyCluster, "mycluster"},
+			expectError:     nil,
+		}),
+		Entry("valid device tag - machine", testCaseDeviceTagFromString{
+			tagString:       "caphv-machine-name=mymachine",
+			expectDeviceTag: DeviceTag{DeviceTagKeyMachine, "mymachine"},
+			expectError:     nil,
+		}),
+		Entry("device tag key does not exist", testCaseDeviceTagFromString{
+			tagString:       "wrongkey=value",
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrDeviceTagKeyInvalid,
+		}),
+		Entry("device tag has empty value", testCaseDeviceTagFromString{
+			tagString:       "caphv-cluster-name=",
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrDeviceTagEmptyValue,
+		}),
+		Entry("device tag has empty key", testCaseDeviceTagFromString{
+			tagString:       "=value",
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrDeviceTagEmptyKey,
+		}),
+		Entry("device tag has invalid format", testCaseDeviceTagFromString{
+			tagString:       "key1=key2=value",
+			expectDeviceTag: DeviceTag{},
+			expectError:     ErrDeviceTagInvalidFormat,
+		}),
+	)
+})
+
+var _ = Describe("Test DeviceTag.ToString", func() {
+	type testCaseDeviceTagToString struct {
+		deviceTag    DeviceTag
+		expectString string
+	}
+
+	DescribeTable("Test DeviceTag.ToString",
+		func(tc testCaseDeviceTagToString) {
+			Expect(tc.deviceTag.ToString()).Should(Equal(tc.expectString))
+		},
+		Entry("cluster key", testCaseDeviceTagToString{
+			deviceTag:    DeviceTag{DeviceTagKeyCluster, "mycluster"},
+			expectString: "caphv-cluster-name=mycluster",
+		}),
+		Entry("machine key", testCaseDeviceTagToString{
+			deviceTag:    DeviceTag{DeviceTagKeyMachine, "mymachine"},
+			expectString: "caphv-machine-name=mymachine",
+		}),
+	)
+})
+
+var _ = Describe("Test DeviceTag.IsInStringList", func() {
+	type testCaseDeviceTagIsInStringList struct {
+		deviceTag  DeviceTag
+		tagList    []string
+		expectBool bool
+	}
+
+	DescribeTable("Test DeviceTag.IsInStringList",
+		func(tc testCaseDeviceTagIsInStringList) {
+			Expect(tc.deviceTag.IsInStringList(tc.tagList)).Should(Equal(tc.expectBool))
+		},
+		Entry("deviceTag exists among multiple", testCaseDeviceTagIsInStringList{
+			deviceTag:  DeviceTag{DeviceTagKeyCluster, "mycluster"},
+			tagList:    []string{"caphv-cluster-name=mycluster", "othertag", "caphv-machine-name=mymachine"},
+			expectBool: true,
+		}),
+		Entry("deviceTag does not exists among multiple", testCaseDeviceTagIsInStringList{
+			deviceTag:  DeviceTag{DeviceTagKeyCluster, "mycluster"},
+			tagList:    []string{"caphv-cluster-type=mytype", "othertag", "caphv-machine-name=mymachine"},
+			expectBool: false,
+		}),
+		Entry("deviceTag exists among multiple - machine tag", testCaseDeviceTagIsInStringList{
+			deviceTag:  DeviceTag{DeviceTagKeyMachine, "mymachine"},
+			tagList:    []string{"caphv-machine-name=mymachine", "othertag"},
+			expectBool: true,
+		}),
+	)
+})
+
+var _ = Describe("Test DeviceTag.RemoveFromList", func() {
+	type testCaseDeviceTagRemoveFromList struct {
+		deviceTag     DeviceTag
+		tagList       []string
+		expectTagList []string
+		expectUpdated bool
+	}
+
+	DescribeTable("Test DeviceTag.RemoveFromList",
+		func(tc testCaseDeviceTagRemoveFromList) {
+			tagList, updated := tc.deviceTag.RemoveFromList(tc.tagList)
+			Expect(tagList).Should(Equal(tc.expectTagList))
+			Expect(updated).Should(Equal(tc.expectUpdated))
+		},
+		Entry("deviceTag exists among multiple", testCaseDeviceTagRemoveFromList{
+			deviceTag:     DeviceTag{DeviceTagKeyCluster, "mycluster"},
+			tagList:       []string{"caphv-cluster-name=mycluster", "othertag", "caphv-machine-name=mymachine"},
+			expectTagList: []string{"othertag", "caphv-machine-name=mymachine"},
+			expectUpdated: true,
+		}),
+		Entry("deviceTag exists and key exists twice", testCaseDeviceTagRemoveFromList{
+			deviceTag:     DeviceTag{DeviceTagKeyCluster, "mycluster"},
+			tagList:       []string{"caphv-cluster-name=mycluster", "caphv-cluster-name=othercluster", "caphv-machine-name=mymachine"},
+			expectTagList: []string{"caphv-cluster-name=othercluster", "caphv-machine-name=mymachine"},
+			expectUpdated: true,
+		}),
+		Entry("deviceTag exists twice", testCaseDeviceTagRemoveFromList{
+			deviceTag:     DeviceTag{DeviceTagKeyCluster, "mycluster"},
+			tagList:       []string{"caphv-cluster-name=mycluster", "caphv-cluster-name=mycluster", "caphv-machine-name=mymachine"},
+			expectTagList: []string{"caphv-machine-name=mymachine"},
+			expectUpdated: true,
+		}),
+		Entry("deviceTag exists among multiple - machine tag", testCaseDeviceTagRemoveFromList{
+			deviceTag:     DeviceTag{DeviceTagKeyMachine, "mymachine"},
+			tagList:       []string{"caphv-cluster-type=mytype", "othertag", "caphv-machine-name=mymachine"},
+			expectTagList: []string{"caphv-cluster-type=mytype", "othertag"},
+			expectUpdated: true,
+		}),
+		Entry("deviceTag does not exist among multiple", testCaseDeviceTagRemoveFromList{
+			deviceTag:     DeviceTag{DeviceTagKeyMachine, "mynewmachine"},
+			tagList:       []string{"caphv-cluster-type=mytype", "othertag", "caphv-machine-name=mymachine"},
+			expectTagList: []string{"caphv-cluster-type=mytype", "othertag", "caphv-machine-name=mymachine"},
+			expectUpdated: false,
+		}),
+		Entry("empty tag list", testCaseDeviceTagRemoveFromList{
+			deviceTag:     DeviceTag{DeviceTagKeyMachine, "mynewmachine"},
+			tagList:       []string{},
+			expectTagList: []string{},
+			expectUpdated: false,
+		}),
+		Entry("nil tag list", testCaseDeviceTagRemoveFromList{
+			deviceTag:     DeviceTag{DeviceTagKeyMachine, "mynewmachine"},
+			tagList:       nil,
+			expectTagList: []string{},
+			expectUpdated: false,
+		}),
+	)
+})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adding DeviceTag and DeviceTagKey objects that make it easier to handle Hivelocity device tags. They are strings but we expect a certain pattern. If this pattern is not matched, a tag is invalid. The new objects have methods to check whether a tag string is valid or not. They are easier to use than the previous utility functions.
On top, some small bugs have been fixed in the provisioning process.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
