### PR TITLE
:sparkles: Implementing state machine for deleting

### DIFF
--- a/api/v1alpha1/hivelocitymachine_types.go
+++ b/api/v1alpha1/hivelocitymachine_types.go
@@ -64,6 +64,18 @@ const (
 
 	// StateDeviceProvisioned .
 	StateDeviceProvisioned ProvisioningState = "provisioned"
+
+	// StateDeleteDeviceShutdown .
+	StateDeleteDeviceShutdown ProvisioningState = "delete-shutdown"
+
+	// StateDeleteDeviceDeProvision .
+	StateDeleteDeviceDeProvision ProvisioningState = "delete-deprovision"
+
+	// StateDeleteDeviceDissociate .
+	StateDeleteDeviceDissociate ProvisioningState = "delete-dissociate"
+
+	// StateDeleteDevice .
+	StateDeleteDevice ProvisioningState = "delete"
 )
 
 // ErrorType indicates the class of problem that has caused the Host resource

--- a/pkg/services/hivelocity/device/state_machine.go
+++ b/pkg/services/hivelocity/device/state_machine.go
@@ -24,7 +24,9 @@ import (
 
 	"github.com/go-logr/logr"
 	infrav1 "github.com/hivelocity/cluster-api-provider-hivelocity/api/v1alpha1"
+	hvclient "github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/util/record"
 )
 
 // stateMachine is a finite state machine that manages transitions between
@@ -54,11 +56,14 @@ type stateHandler func(context.Context) actionResult
 
 func (sm *stateMachine) handlers() map[infrav1.ProvisioningState]stateHandler {
 	return map[infrav1.ProvisioningState]stateHandler{
-		infrav1.StateAssociateDevice:      sm.handleAssociateDevice,
-		infrav1.StateVerifyAssociate:      sm.handleVerifyAssociate,
-		infrav1.StateEnsureDeviceShutDown: sm.handleEnsureDeviceShutDown,
-		infrav1.StateProvisionDevice:      sm.handleProvisionDevice,
-		infrav1.StateDeviceProvisioned:    sm.handleDeviceProvisioned,
+		infrav1.StateAssociateDevice:         sm.handleAssociateDevice,
+		infrav1.StateVerifyAssociate:         sm.handleVerifyAssociate,
+		infrav1.StateEnsureDeviceShutDown:    sm.handleEnsureDeviceShutDown,
+		infrav1.StateProvisionDevice:         sm.handleProvisionDevice,
+		infrav1.StateDeviceProvisioned:       sm.handleDeviceProvisioned,
+		infrav1.StateDeleteDeviceShutdown:    sm.handleDeleteDeviceShutdown,
+		infrav1.StateDeleteDeviceDeProvision: sm.handleDeleteDeviceDeProvision,
+		infrav1.StateDeleteDeviceDissociate:  sm.handleDeleteDeviceDissociate,
 	}
 }
 
@@ -143,6 +148,40 @@ func (sm *stateMachine) handleDeviceProvisioned(ctx context.Context) actionResul
 	actResult := sm.reconciler.actionDeviceProvisioned(ctx)
 	if _, ok := actResult.(actionComplete); ok {
 		sm.nextState = infrav1.StateDeviceProvisioned
+	}
+	return actResult
+}
+
+func (sm *stateMachine) handleDeleteDeviceShutdown(ctx context.Context) actionResult {
+	actResult := sm.reconciler.actionEnsureDeviceShutDown(ctx)
+	if _, ok := actResult.(actionComplete); ok {
+		sm.nextState = infrav1.StateDeleteDeviceDeProvision
+	}
+	actionErr, ok := actResult.(actionError)
+	if ok {
+		// Filter out NotFound error. If device is not there any more, we just need to delete this machine.
+		if errors.Is(actionErr.err, hvclient.ErrDeviceNotFound) {
+			sm.log.Info("Unable to locate Hivelocity device by ID or tags")
+			record.Warnf(sm.hvMachine, "NoDeviceFound", "Unable to find matching Hivelocity device for %s", sm.hvMachine.Name)
+			sm.nextState = infrav1.StateDeleteDevice
+			return actionComplete{}
+		}
+	}
+	return actResult
+}
+
+func (sm *stateMachine) handleDeleteDeviceDeProvision(ctx context.Context) actionResult {
+	actResult := sm.reconciler.actionDeleteDeviceDeProvision(ctx)
+	if _, ok := actResult.(actionComplete); ok {
+		sm.nextState = infrav1.StateDeleteDevice
+	}
+	return actResult
+}
+
+func (sm *stateMachine) handleDeleteDeviceDissociate(ctx context.Context) actionResult {
+	actResult := sm.reconciler.actionDeleteDeviceDissociate(ctx)
+	if _, ok := actResult.(actionComplete); ok {
+		sm.nextState = infrav1.StateDeleteDevice
 	}
 	return actResult
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature 

**What this PR does / why we need it**:
We have the following states: When a machine is supposed to be deleted, we first check in which provisioning state we are. When the provisioning of the device is not yet finished, we can just remove the relevant tags of the device. If it is provisioned already, then we need to shut the device down and, after this is done, re-provision it with a default image. In this way, the device is removed from the cluster.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
