### PR TITLE
:bug: Update waiting times for shutdown of device

### DIFF
--- a/pkg/services/hivelocity/device/device.go
+++ b/pkg/services/hivelocity/device/device.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	infrav1 "github.com/hivelocity/cluster-api-provider-hivelocity/api/v1alpha1"
@@ -266,13 +267,23 @@ func (s *Service) actionEnsureDeviceShutDown(ctx context.Context) actionResult {
 		return actionComplete{}
 	}
 
+	// temp check for unit tests. We need a better solution for this.
+	if os.Getenv("IS_UNIT_TEST") == "true" {
+		return actionContinue{}
+	}
+
+	// device has been shut down for the first time now
+	if err == nil {
+		return actionContinue{delay: 3 * time.Minute}
+	}
+
 	// device is not shut down yet - wait and call the function again
 	log.Info("Device is not shut down yet", "error from ShutDown endpoint", err)
 
 	// wait for another 10 seconds
 	// TODO: Make this flexible for unit tests that don't want to wait here and real-world cases where we
 	// have to wait longer for a device to be shut down
-	return actionContinue{delay: 1 * time.Second}
+	return actionContinue{delay: 30 * time.Second}
 }
 
 // actionProvisionDevice provisions the device.

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -91,6 +91,10 @@ func init() {
 		ErrorIfCRDPathMissing: true,
 		CRDDirectoryPaths:     crdPaths,
 	}
+
+	if err := os.Setenv("IS_UNIT_TEST", "true"); err != nil {
+		panic(err)
+	}
 }
 
 type (


### PR DESCRIPTION
**What type of PR is this?**
/kind bug               Fixes a newly discovered bug.


**What this PR does / why we need it**:
The current waiting time of one second makes the controller run into a rate limit very quickly. Instead, the controller waits for a long time after the device has been actually shut down and then reconciles every 30 seconds to see whether the shutdown has been completed.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

