### PR TITLE
:seedling: copy HV API Key to target cluster.

### DIFF
--- a/controllers/hivelocitymachine_controller.go
+++ b/controllers/hivelocitymachine_controller.go
@@ -132,6 +132,7 @@ func (r *HivelocityMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			Cluster:           cluster,
 			HivelocityCluster: hvCluster,
 			HVClient:          hvClient,
+			APIReader:         r.APIReader,
 		},
 		Machine:           machine,
 		HivelocityMachine: hivelocityMachine,

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -37,6 +37,7 @@ import (
 // ClusterScopeParams defines the input parameters used to create a new scope.
 type ClusterScopeParams struct {
 	Client            client.Client
+	APIReader         client.Reader
 	Logger            logr.Logger
 	HVClient          hvclient.Client
 	Cluster           *clusterv1.Cluster
@@ -64,6 +65,7 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 	return &ClusterScope{
 		Logger:            params.Logger,
 		Client:            params.Client,
+		APIReader:         params.APIReader,
 		Cluster:           params.Cluster,
 		HivelocityCluster: params.HivelocityCluster,
 		HVClient:          params.HVClient,
@@ -75,6 +77,7 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 type ClusterScope struct {
 	logr.Logger
 	Client      client.Client
+	APIReader   client.Reader
 	patchHelper *patch.Helper
 	HVClient    hvclient.Client
 
@@ -183,7 +186,7 @@ func (s *ClusterScope) ListMachines(ctx context.Context) ([]*clusterv1.Machine, 
 	return machineList, hivelocityMachineList, nil
 }
 
-// IsControlPlaneReady returns if a machine is a control-plane.
+// IsControlPlaneReady returns nil if the control plane is ready.
 func IsControlPlaneReady(ctx context.Context, c clientcmd.ClientConfig) error {
 	restConfig, err := c.ClientConfig()
 	if err != nil {

--- a/test/hvapi/main.go
+++ b/test/hvapi/main.go
@@ -87,7 +87,7 @@ write_files:
 	path: /opt/test.txt
 	`
 	opts := hv.BareMetalDeviceUpdate{
-		Hostname: "my-host-name.example.com",
+		Hostname:       "my-host-name.example.com",
 		OsName:         "Ubuntu 20.x",
 		PublicSshKeyId: 918,
 		Script:         script,


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->


**What type of PR is this?**
/kind feature           New functionality.

**What this PR does / why we need it**:

The CCM of the workload-cluster needs the HV API key to access the API of Hivelocity.

The secret gets now copied from the mgt-cluster to the wl-cluster.

