### PR TITLE
:seedling: fix duplicate machine tags.

### DIFF
--- a/controllers/hivelocitymachine_controller_test.go
+++ b/controllers/hivelocitymachine_controller_test.go
@@ -224,6 +224,11 @@ var _ = Describe("HivelocityMachineReconciler", func() {
 					testEnv.GetLogger().Info("Machine has wrong providerID")
 					return false
 				}
+				if hvMachine.Spec.Status.ProvisioningState != infrav1.StateDeviceProvisioned {
+					testEnv.GetLogger().Info("hvMachine.Spec.Status.ProvisioningState != infrav1.StateDeviceProvisioned.",
+						"ProvisioningState", hvMachine.Spec.Status.ProvisioningState)
+					return false
+				}
 				return true
 			}, timeout, time.Second).Should(BeTrue())
 			hvClient := testEnv.HVClientFactory.NewClient("dummy-key")
@@ -231,9 +236,10 @@ var _ = Describe("HivelocityMachineReconciler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(device.Tags).Should(BeEquivalentTo([]string{
 				"caphv-device-type=hvCustom",
-				"caphv-cluster-name=hv-test1",
 				"caphv-cluster-hv-test1=owned",
+				"caphv-cluster-name=hv-test1",
 				fmt.Sprintf("caphv-machine-name=%s", hvMachine.Name),
+				"caphv-machine-type=worker",
 			}))
 		})
 	})

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -114,7 +114,7 @@ func (m *MachineScope) DeviceTagMachineType() hvtag.DeviceTag {
 		value = "worker"
 	}
 	return hvtag.DeviceTag{
-		Key:   hvtag.DeviceTagKeyCluster,
+		Key:   hvtag.DeviceTagKeyMachineType,
 		Value: value,
 	}
 }

--- a/pkg/services/hivelocity/client/mock/mock_client.go
+++ b/pkg/services/hivelocity/client/mock/mock_client.go
@@ -175,6 +175,8 @@ func (c *mockedHVClient) ProvisionDevice(ctx context.Context, deviceID int32, op
 	if !ok {
 		return hv.BareMetalDevice{}, fmt.Errorf("[ProvisionDevice] deviceID %d unknown", deviceID)
 	}
+	device.Tags = opts.Tags
+	c.store.idMap[deviceID] = device
 	return device, nil
 }
 

--- a/pkg/services/hivelocity/client/mock/mock_client_test.go
+++ b/pkg/services/hivelocity/client/mock/mock_client_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	hvclient "github.com/hivelocity/cluster-api-provider-hivelocity/pkg/services/hivelocity/client"
+	hv "github.com/hivelocity/hivelocity-client-go/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,4 +71,17 @@ func Test_NewMockedHVClientFactory(t *testing.T) {
 	device, err = clientNewF.GetDevice(ctx, FreeDeviceID)
 	require.NoError(t, err)
 	require.ElementsMatch(t, device.Tags, []string{"caphv-device-type=hvCustom"})
+}
+
+func Test_ProvisionDevice(t *testing.T) {
+	factory := NewMockedHVClientFactory()
+	client := factory.NewClient("dummy-key")
+	ctx := context.Background()
+	_, err := client.ProvisionDevice(ctx, FreeDeviceID, hv.BareMetalDeviceUpdate{
+		Tags: []string{"dummyTag"},
+	})
+	require.NoError(t, err)
+	device, err := client.GetDevice(ctx, FreeDeviceID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"dummyTag"}, device.Tags)
 }

--- a/pkg/services/hivelocity/device/device.go
+++ b/pkg/services/hivelocity/device/device.go
@@ -116,9 +116,10 @@ func (s *Service) actionAssociateDevice(ctx context.Context) actionResult {
 
 	// associate this device with the machine object by setting tags
 	device.Tags = append(device.Tags,
-		s.scope.HivelocityCluster.DeviceTag().ToString(),
 		s.scope.HivelocityCluster.DeviceTagOwned().ToString(),
+		s.scope.HivelocityCluster.DeviceTag().ToString(),
 		s.scope.HivelocityMachine.DeviceTag().ToString(),
+		s.scope.DeviceTagMachineType().ToString(),
 	)
 
 	if err := s.scope.HVClient.SetDeviceTags(ctx, device.DeviceId, device.Tags); err != nil {
@@ -298,14 +299,6 @@ func (s *Service) actionProvisionDevice(ctx context.Context) actionResult {
 	if err != nil {
 		return actionError{err: fmt.Errorf("failed to get device image: %w", err)}
 	}
-
-	tags := []string{
-		s.scope.HivelocityCluster.DeviceTag().ToString(),
-		s.scope.HivelocityMachine.DeviceTag().ToString(),
-		s.scope.DeviceTagMachineType().ToString(),
-	}
-
-	device.Tags = append(device.Tags, tags...)
 
 	opts := hv.BareMetalDeviceUpdate{
 		Hostname:    fmt.Sprintf("%s.example.com", s.scope.Name()), // TODO: HV API requires a FQDN.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug               Fixes a newly discovered bug.


**What this PR does / why we need it**:


Tags on HV machines are sometime duplicate.

```
{
  "deviceId": 15337,
 ...
 "tags": [
    "caphv-device-type=hvWorker",
    "caphv-cluster-name=hvtest-guettli",
    "caphv-cluster-hvtest-guettli=owned",
    "caphv-machine-name=hvtest-guettli-md-0-5pr2l",
    "caphv-cluster-name=hvtest-guettli",
    "caphv-machine-name=hvtest-guettli-md-0-5pr2l",
    "caphv-cluster-name=worker"
  ]
}
```

duplicate: caphv-cluster-name=hvtest-guettli caphv-machine-name=hvtest-guettli-md-0-5pr2l

And: caphv-cluster-name=worker looks strange.


Fixes #70 
