### PR TITLE
:seedling: e2e test via web-gui provide "tag".

### DIFF
--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -1,6 +1,10 @@
 name: E2E PR Blocking
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        default: manual
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature          

**What this PR does / why we need it**:

the e2e test could not get started via Github web-gui, since a tag is required.

