### PR TITLE
:seedling: fix typo in e2e timeout config.

### DIFF
--- a/test/e2e/config/hivelocity-ci.yaml
+++ b/test/e2e/config/hivelocity-ci.yaml
@@ -124,7 +124,7 @@ variables:
   REDACT_LOG_SCRIPT: "../../hack/log/redact.sh"
 
 intervals:
-  defaults/wait-controllers: ["8m", "10s"] ## wait until initBootstrapCluster has finished.
+  default/wait-controllers: ["8m", "10s"] ## wait until initBootstrapCluster has finished.
   default/wait-cluster: ["5m", "10s"] ## wait until Infrastructure == ready and ControlPlaneEndpoint is valid
   default/wait-control-plane: ["20m", "10s"] ## wait until first control plane is ready
   default/wait-worker-nodes: ["20m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready

--- a/test/e2e/config/hivelocity.yaml
+++ b/test/e2e/config/hivelocity.yaml
@@ -130,7 +130,7 @@ variables:
   REDACT_LOG_SCRIPT: "../../hack/log/redact.sh"
 
 intervals:
-  defaults/wait-controllers: ["8m", "10s"] ## wait until initBootstrapCluster has finished.
+  default/wait-controllers: ["8m", "10s"] ## wait until initBootstrapCluster has finished.
   default/wait-cluster: ["5m", "10s"] ## wait until Infrastructure == ready and ControlPlaneEndpoint is valid
   default/wait-control-plane: ["90m", "10s"] ## wait until first control plane is ready
   default/wait-worker-nodes: ["90m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready


### PR DESCRIPTION
**What type of PR is this?**

/kind bug               Fixes a newly discovered bug.

The e2e timeout config contained a typo. The timeout of 8min was not applied up to now.
