### PR TITLE
:seedling: remove tilt-settings.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ env-vars-for-wl-cluster:
 	HIVELOCITY_API_KEY HIVELOCITY_SSH_KEY HIVELOCITY_WORKER_MACHINE_TYPE KUBERNETES_VERSION WORKER_MACHINE_COUNT \
 	HIVELOCITY_IMAGE_NAME HIVELOCITY_REGION
 
-create-workload-cluster: env-vars-for-wl-cluster $(HOME)/.ssh/$(INFRA_PROVIDER).pub $(CLUSTERCTL) $(KUSTOMIZE) $(ENVSUBST) install-crds ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.yaml
+create-workload-cluster: env-vars-for-wl-cluster $(HOME)/.ssh/$(INFRA_PROVIDER).pub $(CLUSTERCTL) $(KUSTOMIZE) $(ENVSUBST) install-crds ## Creates a workload-cluster.
 	# Create workload Cluster.
 	rm -f $(WORKER_CLUSTER_KUBECONFIG)
 	go run ./cmd upload-ssh-pub-key $$HIVELOCITY_SSH_KEY $(HOME)/.ssh/$(INFRA_PROVIDER).pub

--- a/Tiltfile
+++ b/Tiltfile
@@ -38,12 +38,6 @@ settings = {
 
 keys = ["HIVELOCITY_SSH_KEY"]
 
-# global settings
-settings.update(read_yaml(
-    "tilt-settings.yaml",
-    default={},
-))
-
 if settings.get("trigger_mode") == "manual":
     trigger_mode(TRIGGER_MODE_MANUAL)
 
@@ -116,13 +110,6 @@ def append_arg_for_container_in_deployment(yaml_stream, name, namespace, contain
 def fixup_yaml_empty_arrays(yaml_str):
     yaml_str = yaml_str.replace("conditions: null", "conditions: []")
     return yaml_str.replace("storedVersions: null", "storedVersions: []")
-
-
-def validate_needed_keys():
-    substitutions = settings.get("kustomize_substitutions", {})
-    missing = [k for k in keys if k not in substitutions]
-    if missing:
-        fail("missing kustomize_substitutions keys {} in tilt-setting.json".format(missing))
 
 
 def set_env_variables():
@@ -275,8 +262,6 @@ ensure_envsubst()
 ensure_kustomize()
 
 include_user_tilt_files()
-
-validate_needed_keys()
 
 load("ext://cert_manager", "deploy_cert_manager")
 

--- a/docs/book/src/developer/repository-layout.md
+++ b/docs/book/src/developer/repository-layout.md
@@ -11,12 +11,12 @@
 |                         # present in CAPHV.
 |                         # The API folder has subfolders for each supported API version.
 |
-├── _artifacts            # This directory is created during e2e tests. 
+├── _artifacts            # This directory is created during e2e tests.
 |                         # It contains yaml files and logs.
 |
 ├── bin                   # Binaries, mostly for envtests.
 |
-├── config                # This is a Kubernetes manifest folder containing application 
+├── config                # This is a Kubernetes manifest folder containing application
 |                         # resource configurations as
 |                         # kustomize YAML definitions. These are generated from other folders in the
 |                         # repo using`make generate-manifests`.
@@ -43,6 +43,5 @@
 ├── test                  # Config and code for e2e tests.
 |
 ├── Tiltfile              # Configuration for https://tilt.dev/.
-├── tilt-provider.yaml
-└── tilt-settings.yaml
+└── tilt-provider.yaml
 ```

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -6,7 +6,7 @@ We use [Tilt](https://tilt.dev/) to start a development cluster.
 
 ## Setting Tilt up
 
-You need to create a `tilt-settings.yaml` file and specify the values you need. In the git repo is already a file. You can adapt it to your needs.
+You need to create a `.envrc` file and specify the values you need. In the git repo is already a file. You can adapt it to your needs.
 
 Machines with the corresponding `caphv-device-type` tag will get conditionless provisioned. Be sure that you don't provision machines which run valuable workload!
 
@@ -40,7 +40,7 @@ Open a terminal and execute [make watch](../topics/make-watch.md)
 
 ![make watch](../topics/make-watch.jpg)
 
-The output of [make watch](../topics/make-watch.md) updates itself. You can monitor the progress of the CAPH controller.
+The output of [make watch](../topics/make-watch.md) updates itself. You can monitor the progress of the CAPHV controller.
 
 Working with baremetal servers takes time. It takes roughly 20 minutes
 until the ssh port of the first control plane is reachable.

--- a/docs/book/src/user/getting-started.md
+++ b/docs/book/src/user/getting-started.md
@@ -43,7 +43,8 @@ At this moment we only support cluster management with tilt. So follow below ins
 
 ### Create a management cluster
 
-Please run below command and this will use `tilt-provider.yaml` to create the provider and `tilt-settings.yaml` to get all the environment variable -
+Please run below command and this will use `tilt-provider.yaml` to create the provider and
+`.envrc` to get all the environment variables.
 ```shell
 # Please run the command from root of this repository
 make tilt-up

--- a/tilt-settings.yaml
+++ b/tilt-settings.yaml
@@ -1,10 +1,1 @@
 kustomize_substitutions:
-  HIVELOCITY_SSH_KEY: ssh-key-hivelocity-pub
-  HIVELOCITY_REGION: LAX2
-
-  HIVELOCITY_CONTROL_PLANE_MACHINE_TYPE: hvControlPlane # caphv-device-type=hvControlPlane
-  CONTROL_PLANE_MACHINE_COUNT: "1"
-  HIVELOCITY_WORKER_MACHINE_TYPE: hvWorker # caphv-device-type=hvWorker
-  WORKER_MACHINE_COUNT: "1"
-  KUBERNETES_VERSION: v1.25.2
-  HIVELOCITY_IMAGE_NAME: 1.25.2-ubuntu-20.04-containerd


### PR DESCRIPTION
env vars get set via .envrc (or any other way you like)


**What type of PR is this?**
/kind feature           New functionality.


**What this PR does / why we need it**:

We don't need two places to configure env vars. Having one is easier to understand.

(This change was still on my local machine - from july).

