### PR TITLE
:seedling: add providerID to logs and increase CI wait time.

### DIFF
--- a/controllers/hivelocitymachine_controller.go
+++ b/controllers/hivelocitymachine_controller.go
@@ -75,7 +75,7 @@ func (r *HivelocityMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	log = log.WithValues("HivelocityMachine", klog.KObj(hivelocityMachine))
+	log = log.WithValues("HivelocityMachine", klog.KObj(hivelocityMachine), "providerID", hivelocityMachine.Spec.ProviderID)
 
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r.Client, hivelocityMachine.ObjectMeta)

--- a/test/e2e/config/hivelocity-ci.yaml
+++ b/test/e2e/config/hivelocity-ci.yaml
@@ -126,6 +126,6 @@ variables:
 intervals:
   default/wait-controllers: ["8m", "10s"] ## wait until initBootstrapCluster has finished.
   default/wait-cluster: ["5m", "10s"] ## wait until Infrastructure == ready and ControlPlaneEndpoint is valid
-  default/wait-control-plane: ["25m", "10s"] ## wait until first control plane is ready.
-  default/wait-worker-nodes: ["20m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
+  default/wait-control-plane: ["26m", "10s"] ## wait until first control plane is ready.
+  default/wait-worker-nodes: ["26m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
   default/wait-delete-cluster: ["20m", "10s"] ## wait until cluster is deleted


### PR DESCRIPTION
**What type of PR is this?**

Add providerID to logs.

This makes it easier to see which machine a log line belongs to.