### PR TITLE
🌱 update builder image to use go 1.21

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -16,10 +16,10 @@
 # pipelines.
 # If you make changes to this Dockerfile run `make builder-image-push`.
 
-# Install Lychee (Link Checker)
-FROM docker.io/library/alpine:3.17.3@sha256:b6ca290b6b4cdcca5b3db3ffa338ee0285c11744b4a6abaa9627746ee3291d8d as lychee
+# Install Lychee
+FROM docker.io/library/alpine:3.18.5@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389 as lychee
 # update: datasource=github-tags depName=lycheeverse/lychee versioning=semver
-ENV LYCHEE_VERSION="v0.11.1"
+ENV LYCHEE_VERSION="v0.13.0"
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl && \
     curl -L -o /tmp/lychee-${LYCHEE_VERSION}.tgz https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
@@ -28,9 +28,9 @@ RUN apk add --no-cache curl && \
     rm -rf /tmp/linux-amd64 /tmp/lychee-${LYCHEE_VERSION}.tgz
 
 # Install Golang CI Lint
-FROM docker.io/library/alpine:3.17.3@sha256:b6ca290b6b4cdcca5b3db3ffa338ee0285c11744b4a6abaa9627746ee3291d8d as golangci
+FROM docker.io/library/alpine:3.18.5@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389 as golangci
 # update: datasource=github-tags depName=golangci/golangci-lint versioning=semver
-ENV GOLANGCI_VERSION="v1.52.2"
+ENV GOLANGCI_VERSION="v1.55.2"
 WORKDIR /
 # hadolint ignore=DL3018,DL4006
 RUN apk add --no-cache curl && \
@@ -40,17 +40,17 @@ RUN apk add --no-cache curl && \
 FROM docker.io/hadolint/hadolint:v2.12.0-alpine@sha256:7dba9a9f1a0350f6d021fb2f6f88900998a4fb0aaf8e4330aa8c38544f04db42 as hadolint
 
 # Install Trivy
-FROM docker.io/aquasec/trivy:0.39.0@sha256:ab281f43ee11b8ea5443ca8897641441f04f14e8832fefd103d32b4acd7055e1 as trivy
+FROM docker.io/aquasec/trivy:0.47.0@sha256:163b935486680eefe46e38534eaeabd95e36e0e6b7b3fa5d08fb1e05c6ad9f20 as trivy
 
 ############################
 # Build Image Base #
 ############################
-FROM docker.io/library/golang:1.20.2-bullseye@sha256:2101aa981e68ab1e06e3d4ac35ae75ed122f0380e5331e3ae4ba7e811bf9d256
+FROM docker.io/library/golang:1.21.4-bullseye@sha256:404427572053ec4a7be94b540895fc0eade26f345048196b9ad71c061bf279db
 
 # update: datasource=repology depName=debian_11/skopeo versioning=loose
 ENV SKOPEO_VERSION="1.2.2+dfsg1-1+b6"
 # update: datasource=github-tags depName=adrienverge/yamllint versioning=semver
-ENV YAMLLINT_VERSION="v1.30.0"
+ENV YAMLLINT_VERSION="v1.33.0"
 # update: datasource=github-tags depName=opt-nc/yamlfixer versioning=semver
 ENV YAMLFIXER_VERSION="0.9.15"
 


### PR DESCRIPTION
this commit updates builder image Dockerfile to use go 1.21 and it also updates some other components/tools that we use inside the container.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->


**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature           New functionality.
/kind bug               Fixes a newly discovered bug.
/kind api-change        Adds, removes, or changes an API.
/kind cleanup           Adds tests, refactors, fixes old bugs.
/kind deprecation       Related to a feature/enhancement marked for deprecation.
/kind design            Related to design.
/kind documentation     Adds documentation.
/kind failing-test      CI test case is failing consistently.
/kind flake             CI test case is showing intermittent failures.
/kind other             Related to updating dependencies, minor changes or other.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional, depending on the PR. -->

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

